### PR TITLE
fix: fix issue with missing python 2 installation

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: python:2.7.18-buster
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potentially a fix for #2 by running the prebuild job in a python2 container. Pretty unsure about whether this works as intended though.