### PR TITLE
fix: build with 16KB page size support

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -91,6 +91,13 @@ jobs:
         working-directory: ./package
         run: bare-make install
 
+      - name: Rename
+        working-directory: ./package
+        # bare-make uses kebab-case for filenames, but better-sqlite3 expects snake_case for the .node file
+        run: |
+          mv ./prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/better-sqlite3.node \
+          ./prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/better_sqlite3.node
+
       - name: Upload original prebuild artifacts # mostly for debugging purposes
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -21,9 +21,10 @@ on:
         required: false
         default: true
         type: boolean
-      release_tag:
-        description: "Release tag"
+      release_tag_suffix:
+        description: "Release tag suffix"
         required: false
+        default: "-bare-make"
         type: string
 
 jobs:
@@ -123,4 +124,4 @@ jobs:
           artifactErrorsFailBuild: true
           allowUpdates: true
           replacesArtifacts: true
-          tag: ${{ inputs.release_tag || needs.build.outputs.module_version }}
+          tag: ${{ needs.build.outputs.module_version }}${{ inputs.release_tag_suffix }}

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -68,8 +68,7 @@ jobs:
 
       - name: Install patched cmake-napi
         working-directory: ./package
-        run:
-          npm install -D --ignore-scripts
+        run: npm install -D --ignore-scripts
           cmake-napi@github:digidem/cmake-napi-nodejs-mobile
 
       - name: Copy CMakeLists.txt
@@ -77,9 +76,11 @@ jobs:
 
       - name: Generate
         working-directory: ./package
-        run:
-          bare-make generate --platform ${{ matrix.platform }} --arch
-          ${{matrix.arch }}
+        run: |
+          bare-make generate \
+          --platform ${{ matrix.platform }} \
+          --arch ${{matrix.arch }} \
+          -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
 
       - name: Build
         working-directory: ./package
@@ -92,12 +93,10 @@ jobs:
       - name: Upload original prebuild artifacts # mostly for debugging purposes
         uses: actions/upload-artifact@v4
         with:
-          name:
-            ${{ env.MODULE_NAME }}-${{
+          name: ${{ env.MODULE_NAME }}-${{
             steps.parse-module-version.outputs.version }}-node-${{ env.NODE_ABI
             }}-${{ matrix.platform}}-${{ matrix.arch }}
-          path:
-            ./package/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/*.node
+          path: ./package/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/*.node
 
   release:
     if: ${{ inputs.publish_release }}


### PR DESCRIPTION
We haven't yet been using the bare-make builds of better-sqlite3 in comapeo-mobile, which is why I'm keeping the releases with the `-bare-make` suffix, to avoid messing with current builds. This will need a PR to comapeo-mobile to change downloadPrebuilds to add `-bare-make` to the `version` parameter, and the removal of `test_extension.node` will not be needed any more.

As well as adding the 16kb page size support, I've added a CI step to rename the `.node` file, to match what `better-sqlite3` expects when it tries to load it.

I've tested this by running this workflow to build without releasing, then manually downloaded the build artifacts, added them to nodejs_assets, then ran the debug version of the app and tested creating an observation. I then opened the APK in the Android Studio APK analyzer and checked that it no longer shows an alignment warning for better_sqlite3.node.

 Once we merge we should run the prebuild workflow for release `11.10.0`, keeping the `-bare-make` suffix. Then update comapeo-mobile to download this version.