### PR TITLE
feat: build for ios

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1,12 +1,15 @@
 name: Generate prebuilds
 
+# This workflow is a custom variant of
+# digidem/nodejs-mobile-bare-prebuilds' reusable `prebuild` action. The
+# reusable action can't be used directly because better-sqlite3 ships no
+# CMakeLists.txt — we inject a custom one from this repo — and the
+# built .node file has to be renamed from kebab-case to snake_case for
+# better-sqlite3's bindings loader. The release step does use the
+# reusable release.yml workflow as-is.
+
 env:
-  NODE_VERSION: "20"
   MODULE_NAME: "better-sqlite3"
-  # Needs to match to the corresponding Node version used by NodeJS Mobile
-  # NodeJS Mobile runtime version: https://github.com/nodejs-mobile/nodejs-mobile/blob/main/src/node_mobile_version.h
-  # ABI mapping reference: https://github.com/nodejs-mobile/nodejs-mobile/blob/main/doc/abi_version_registry.json
-  NODE_ABI: 108
 
 on:
   workflow_dispatch:
@@ -21,31 +24,48 @@ on:
         required: false
         default: true
         type: boolean
-      release_tag_suffix:
-        description: "Release tag suffix"
-        required: false
-        default: "-bare-make"
-        type: string
 
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        platform: [android]
-        arch: [arm64, x64, arm]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    name: better-sqlite3 (${{ matrix.platform }}-${{ matrix.arch }})
+        include:
+          - platform: android
+            arch: arm64
+          - platform: android
+            arch: x64
+          - platform: android
+            arch: arm
+          - platform: ios
+            arch: arm64
+          - platform: ios
+            arch: arm64
+            simulator: true
+          - platform: ios
+            arch: x64
+            simulator: true
+    runs-on: ${{ matrix.platform == 'ios' && 'macos-latest' || 'ubuntu-22.04' }}
+    timeout-minutes: 20
+    name: better-sqlite3 (${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.simulator && '-simulator' || '' }})
     outputs:
       module_version: ${{ steps.parse-module-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - name: Compute target
+        id: target
+        run: |
+          suffix=""
+          if [ "${{ matrix.simulator }}" = "true" ]; then
+            suffix="-simulator"
+          fi
+          echo "target=${{ matrix.platform }}-${{ matrix.arch }}${suffix}" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 24
 
       - name: Download npm package and unpack
         run:
@@ -56,6 +76,9 @@ jobs:
         id: parse-module-version
         working-directory: ./package
         run: echo version=$(jq -r .version package.json) >> $GITHUB_OUTPUT
+
+      - name: Copy custom CMakeLists.txt
+        run: cp ./CMakeLists.txt ./package/
 
       - run: npm install -g bare-make
 
@@ -72,16 +95,20 @@ jobs:
         run: npm install -D --ignore-scripts
           cmake-napi@github:digidem/cmake-napi-nodejs-mobile
 
-      - name: Copy CMakeLists.txt
-        run: cp ./CMakeLists.txt ./package/
-
       - name: Generate
         working-directory: ./package
         run: |
+          extra_args=()
+          if [ "${{ matrix.platform }}" = "android" ]; then
+            extra_args+=(-D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384")
+          fi
+          if [ "${{ matrix.simulator }}" = "true" ]; then
+            extra_args+=(--simulator)
+          fi
           bare-make generate \
-          --platform ${{ matrix.platform }} \
-          --arch ${{matrix.arch }} \
-          -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
+            --platform ${{ matrix.platform }} \
+            --arch ${{ matrix.arch }} \
+            "${extra_args[@]}"
 
       - name: Build
         working-directory: ./package
@@ -95,40 +122,41 @@ jobs:
         working-directory: ./package
         # bare-make uses kebab-case for filenames, but better-sqlite3 expects snake_case for the .node file
         run: |
-          mv ./prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/better-sqlite3.node \
-          ./prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/better_sqlite3.node
+          mv ./prebuilds/${{ steps.target.outputs.target }}/better-sqlite3.node \
+          ./prebuilds/${{ steps.target.outputs.target }}/better_sqlite3.node
 
-      - name: Upload original prebuild artifacts # mostly for debugging purposes
-        uses: actions/upload-artifact@v4
+      - name: Upload prebuild artifacts
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.MODULE_NAME }}-${{
-            steps.parse-module-version.outputs.version }}-node-${{ env.NODE_ABI
-            }}-${{ matrix.platform}}-${{ matrix.arch }}
-          path: ./package/prebuilds/${{ matrix.platform }}-${{ matrix.arch }}/*.node
+            steps.parse-module-version.outputs.version }}-${{
+            steps.target.outputs.target }}
+          path: ./package/prebuilds/${{ steps.target.outputs.target }}/*.node
+
+  test-android:
+    needs: build
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-android.yml@v2
+    with:
+      module_spec: better-sqlite3@${{ needs.build.outputs.module_version }}
+      # The default 'smoke' runner (just `require(module)`) doesn't exercise
+      # better-sqlite3's native binding — it's loaded lazily inside the
+      # Database constructor. See test/smoke.js for details.
+      test_runner: custom
+      test_script: test/smoke.js
+
+  test-ios:
+    needs: build
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-ios.yml@v2
+    with:
+      module_spec: better-sqlite3@${{ needs.build.outputs.module_version }}
+      test_runner: custom
+      test_script: test/smoke.js
 
   release:
     if: ${{ inputs.publish_release }}
-    needs: build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: prebuilds
-
-      - run: |
-          mkdir -p artifacts
-          for folder in prebuilds/*/; do
-            folder_name=$(basename "$folder")
-            tar -czvf "artifacts/${folder_name}.tar.gz" -C "prebuilds/${folder_name}" .
-          done
-
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "artifacts/*"
-          artifactErrorsFailBuild: true
-          allowUpdates: true
-          replacesArtifacts: true
-          tag: ${{ needs.build.outputs.module_version }}${{ inputs.release_tag_suffix }}
+    needs: [build, test-android, test-ios]
+    permissions:
+      contents: write
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/release.yml@v2
+    with:
+      module_spec: better-sqlite3@${{ needs.build.outputs.module_version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,17 +157,22 @@ if(target MATCHES "linux")
   )
 endif()
 
-# Test extension (optional)
-add_library(test_extension SHARED)
+# Test extension (optional). Not built on iOS: iOS restricts standalone
+# shared libraries (code signing / framework packaging), and nothing in
+# the main module depends on it — it exists for better-sqlite3's own
+# runtime-loadable-extension test, which we don't run.
+if(NOT target MATCHES "^ios")
+  add_library(test_extension SHARED)
 
-target_sources(
-  test_extension
-  PRIVATE
-    deps/test_extension.c
-)
+  target_sources(
+    test_extension
+    PRIVATE
+      deps/test_extension.c
+  )
 
-target_link_libraries(
-  test_extension
-  PRIVATE
-    sqlite3
-)
+  target_link_libraries(
+    test_extension
+    PRIVATE
+      sqlite3
+  )
+endif()

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,43 @@
+// Smoke test for the better-sqlite3 prebuild running under nodejs-mobile.
+//
+// The upstream default smoke test (just `require(moduleName)`) is
+// meaningless for better-sqlite3: the native binding is loaded lazily
+// inside the Database constructor, so `require('better-sqlite3')` can
+// succeed without ever touching the .node file.
+//
+// better-sqlite3's default loader is `require('bindings')`, which
+// searches build/Release/, build/Debug/, etc. — never prebuilds/<target>/.
+// Rather than relocating the file or patching the loader, we use the
+// `nativeBinding` option Database already supports, pointing it at the
+// prebuild at its installed location in node_modules.
+
+const path = require('path')
+
+const moduleRoot = path.dirname(require.resolve('better-sqlite3/package.json'))
+const target = process.platform + '-' + process.arch
+const bindingPath = path.join(moduleRoot, 'prebuilds', target, 'better_sqlite3.node')
+
+console.log('TAP version 13')
+console.log('1..1')
+
+try {
+  const Database = require('better-sqlite3')
+  const db = new Database(':memory:', { nativeBinding: bindingPath })
+  const row = db.prepare('SELECT 42 AS answer').get()
+  if (!row || row.answer !== 42) {
+    throw new Error('unexpected query result: ' + JSON.stringify(row))
+  }
+  db.close()
+  console.log('ok 1 - better-sqlite3 prebuild loads and SELECT returns 42')
+  process.exit(0)
+} catch (err) {
+  console.log('not ok 1 - better-sqlite3 prebuild failed')
+  console.log('  ---')
+  console.log('  message: ' + JSON.stringify(err && err.message))
+  console.log('  stack: |')
+  for (const line of String((err && err.stack) || err).split('\n')) {
+    console.log('    ' + line)
+  }
+  console.log('  ...')
+  process.exit(1)
+}


### PR DESCRIPTION
We can't use the re-usable shared workflows because better-sqlite3 requires a custom CMakeLists.txt for the build process, and we need custom smoke tests because better-sqlite3 lazily loads the native module when creating a class instance, not when loading the module.