### PR TITLE
fix(android): target API 24 so prebuilds load on Android < 9

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -134,6 +134,13 @@ jobs:
           extra_args=()
           if [ "${{ matrix.platform }}" = "android" ]; then
             extra_args+=(-D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384")
+            # RELR packed relocations (emitted by default when targeting
+            # API >= 28 on recent NDKs; the bare-make toolchain defaults to
+            # android-29) SIGSEGV on Android < 9 — the older linker skips
+            # the unknown DT_ANDROID_RELR entries. Pin to nodejs-mobile's
+            # support floor instead. Mirrors
+            # digidem/nodejs-mobile-bare-prebuilds#9.
+            extra_args+=(-D ANDROID_PLATFORM=android-24)
           fi
           if [ "${{ matrix.simulator }}" = "true" ]; then
             extra_args+=(--simulator)


### PR DESCRIPTION
Companion to digidem/nodejs-mobile-bare-prebuilds#9 — this repo inlines its own copy of the Generate step (custom CMakeLists + snake_case rename), so it didn't pick up that fix.

Without `ANDROID_PLATFORM` pinned, bare-make's toolchain defaults to `android-29` and recent NDKs emit RELR packed relocations (`DT_ANDROID_RELR`), which Android < 9 dynamic linkers skip with an "unused DT entry" warning — the addon then SIGSEGVs at first use. See the full diagnosis and validation matrix on digidem/nodejs-mobile-bare-prebuilds#9 (reproduced on an API 24 emulator and originally on a Galaxy Note 9 / Android 8.1 in BrowserStack).

Confirmed the `11.10.0` / `12.9.0` assets rebuilt today still carry RELR (`llvm-readelf -d`: 3 `DT_ANDROID_RELR` entries, ELF note target API 29) because of this gap. After merging, re-dispatch the prebuilds workflow for both versions; I'll verify the new assets are RELR-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)