### PR TITLE
fix(ci): stop the N-API artifact name falling back to the ABI form

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -246,10 +246,13 @@ jobs:
       nodejs_mobile_version: v${{ matrix.node_version }}
       # Override default artifact name (which assumes <module>-<version>-<target>)
       # because we embed the node ABI; default target for android tests is android-x64.
+      # Inverted deliberately: in GitHub's `a && b || c`, an empty-string `b`
+      # is falsy and falls through to `c`, so the non-empty branch has to be
+      # the one guarded by the condition.
       artifact_name: better-sqlite3-${{ needs.resolve.outputs.module_version }}${{
-        needs.resolve.outputs.napi == 'true' && '' ||
+        needs.resolve.outputs.napi != 'true' &&
         format('-node-{0}', fromJSON(needs.resolve.outputs.abis)[matrix.node_version])
-        }}-android-x64
+        || '' }}-android-x64
 
   test-ios:
     needs: [ resolve, build ]
@@ -265,10 +268,13 @@ jobs:
       nodejs_mobile_version: v${{ matrix.node_version }}
       # Default test-ios target is ios-arm64 (runtime install path) but the
       # artifact comes from the ios-arm64-simulator build.
+      # Inverted deliberately: in GitHub's `a && b || c`, an empty-string `b`
+      # is falsy and falls through to `c`, so the non-empty branch has to be
+      # the one guarded by the condition.
       artifact_name: better-sqlite3-${{ needs.resolve.outputs.module_version }}${{
-        needs.resolve.outputs.napi == 'true' && '' ||
+        needs.resolve.outputs.napi != 'true' &&
         format('-node-{0}', fromJSON(needs.resolve.outputs.abis)[matrix.node_version])
-        }}-ios-arm64-simulator
+        || '' }}-ios-arm64-simulator
 
   release:
     if: ${{ inputs.publish_release }}


### PR DESCRIPTION
All five 13.0.3 builds succeeded but every test leg failed on `Artifact not found for name: better-sqlite3-13.0.3-node-137-android-x64` — the build had uploaded `better-sqlite3-13.0.3-android-x64`.

In GitHub's `a && b || c`, `a && b` evaluates to `b`, and an empty-string `b` is falsy, so it falls through to `c` whatever `a` was. Written as `napi == 'true' && '' || <abi form>`, the ABI form always won. Inverted so the branch guarded by the condition is the non-empty one.